### PR TITLE
Added ethereum network statistics UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Now:
     - http://172.14.0.16:9006
     - http://172.14.0.17:9007
 
+- **Eth Stats**:
+    - http://172.14.0.77:3000
+
 View the `docker-compose-*.yml` files for more information on these containers.
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,16 @@ services:
       quorum_net:
         ipv4_address: '172.14.0.99'
 
+  eth-stats:
+    build: https://github.com/lucashenning/eth-netstats.git
+    ports:
+      - '3000:3000'
+    environment:
+      - WS_SECRET=secret
+    networks:
+      quorum_net:
+        ipv4_address: '172.14.0.77'
+
   quorum1:
     build: 
       context: ./quorum/
@@ -34,7 +44,7 @@ services:
       - CONSTELLATION_OTHERNODES_URL=http://172.14.0.11:9001/
       - CONSTELLATION_HOST=172.14.0.10
       - CONSTELLATION_PORT=9001
-      - GETH_EXTRA_PARAMS=--unlock 0 --password passwords.txt --targetgaslimit 0x47b760
+      - GETH_EXTRA_PARAMS=--unlock 0 --password passwords.txt --targetgaslimit 0x47b760 --ethstats quorum1:secret@eth-stats:3000
 
   quorum2:
     build: 
@@ -56,7 +66,7 @@ services:
       - CONSTELLATION_OTHERNODES_URL=http://172.14.0.11:9001/
       - CONSTELLATION_HOST=172.14.0.12
       - CONSTELLATION_PORT=9002
-      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760
+      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760 --ethstats quorum2:secret@eth-stats:3000
 
   quorum3:
     build: 
@@ -78,7 +88,7 @@ services:
       - CONSTELLATION_OTHERNODES_URL=http://172.14.0.11:9001/
       - CONSTELLATION_HOST=172.14.0.13
       - CONSTELLATION_PORT=9003
-      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760
+      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760 --ethstats quorum3:secret@eth-stats:3000
   
   quorum4:
     build: 
@@ -100,7 +110,7 @@ services:
       - CONSTELLATION_OTHERNODES_URL=http://172.14.0.11:9001/
       - CONSTELLATION_HOST=172.14.0.14
       - CONSTELLATION_PORT=9004
-      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760
+      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760 --ethstats quorum4:secret@eth-stats:3000
   
   quorum5:
     build: 
@@ -122,7 +132,7 @@ services:
       - CONSTELLATION_OTHERNODES_URL=http://172.14.0.11:9001/
       - CONSTELLATION_HOST=172.14.0.15
       - CONSTELLATION_PORT=9005
-      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760
+      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760 --ethstats quorum5:secret@eth-stats:3000
 
   quorum6:
     build: 
@@ -144,7 +154,7 @@ services:
       - CONSTELLATION_OTHERNODES_URL=http://172.14.0.11:9001/
       - CONSTELLATION_HOST=172.14.0.16
       - CONSTELLATION_PORT=9006
-      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760
+      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760 --ethstats quorum6:secret@eth-stats:3000
 
   quorum7:
     build: 
@@ -166,7 +176,7 @@ services:
       - CONSTELLATION_OTHERNODES_URL=http://172.14.0.11:9001/
       - CONSTELLATION_HOST=172.14.0.17
       - CONSTELLATION_PORT=9007
-      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760
+      - GETH_EXTRA_PARAMS=--targetgaslimit 0x47b760 --ethstats quorum7:secret@eth-stats:3000
 
 networks:
   quorum_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,11 @@ services:
         ipv4_address: '172.14.0.99'
 
   eth-stats:
-    build: https://github.com/lucashenning/eth-netstats.git
+    build: https://github.com/DeloitteBlockchain/eth-netstats.git
+    volumes:
+      - ./logs/eth-stats/:/usr/src/app/log/
     ports:
-      - '3000:3000'
+      - "3000:3000"
     environment:
       - WS_SECRET=secret
     networks:


### PR DESCRIPTION
Hey guys, this is awesome work. Thanks a lot for putting this together. Kudos!

I figured you guys could use a UI to make this more tangible and give users the opportunity to see the status of the overall network. Therefore, I added [eth stats](https://github.com/cubedro/eth-netstats) and have each node report to it. Just run `docker-compose up` and go to http://localhost:3000/ 

![image](https://user-images.githubusercontent.com/12414494/44383608-e0045f00-a536-11e8-9020-d930c6265af2.png)

I dockerized eth-stats for this. So, you might want to clone/fork this repo: https://github.com/lucashenning/eth-netstats

Cheers, 
Lucas